### PR TITLE
Decrypt: bypass jwx alg-matching for RFC 7516 §7.2.1 (jwx v3.1+)

### DIFF
--- a/aead.go
+++ b/aead.go
@@ -1,0 +1,44 @@
+package clevis
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// extractEncodedProtectedHeader returns the base64url-encoded protected
+// header ASCII bytes from a JWE in either compact (5 dot-separated segments)
+// or JSON serialization form. The returned slice is the value used as
+// Additional Authenticated Data (AAD) when verifying the AEAD tag per
+// RFC 7516 §5.1 step 14.
+//
+// Why we re-parse: jwx's *jwe.Message stores rawProtectedHeaders as an
+// unexported field; once you mutate any header via the public API and
+// re-marshal, the bytes are re-encoded and differ from the original AAD
+// the JWE was signed with. We need the literal original bytes.
+func extractEncodedProtectedHeader(input []byte) ([]byte, error) {
+	trimmed := bytes.TrimSpace(input)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty JWE input")
+	}
+	if trimmed[0] == '{' {
+		var obj struct {
+			Protected string `json:"protected"`
+		}
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return nil, fmt.Errorf("invalid JWE JSON: %w", err)
+		}
+		if obj.Protected == "" {
+			return nil, fmt.Errorf(`JWE JSON missing "protected" field`)
+		}
+		return []byte(obj.Protected), nil
+	}
+	segs := bytes.Split(trimmed, []byte("."))
+	if len(segs) != 5 {
+		return nil, fmt.Errorf("invalid JWE compact form: expected 5 segments, got %d", len(segs))
+	}
+	if len(segs[0]) == 0 {
+		return nil, fmt.Errorf("JWE compact form has empty protected header")
+	}
+	return segs[0], nil
+}

--- a/aead.go
+++ b/aead.go
@@ -2,6 +2,9 @@ package clevis
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 )
@@ -41,4 +44,97 @@ func extractEncodedProtectedHeader(input []byte) ([]byte, error) {
 		return nil, fmt.Errorf("JWE compact form has empty protected header")
 	}
 	return segs[0], nil
+}
+
+// decryptAEADWithCEK performs the JWE AEAD-decrypt step using a CEK that
+// has already been derived by a clevis pin (tang ECDH-ES, tpm2 unseal,
+// sss combine, etc.). This bypasses jwx's alg-matching layer, which is
+// the source of the RFC 7516 §7.2.1 disjoint-headers rejection on clevis
+// JWEs that intentionally carry alg=ECDH-ES (protected) plus alg=dir
+// (per-recipient).
+//
+// rawInput must be the original JWE bytes (compact or JSON form) so the
+// AAD computed from the encoded protected header matches what the JWE
+// was sealed with. enc is the value of the protected header's "enc"
+// field — typically "A256GCM" for clevis.
+func decryptAEADWithCEK(rawInput []byte, enc string, cek []byte) ([]byte, error) {
+	aad, err := extractEncodedProtectedHeader(rawInput)
+	if err != nil {
+		return nil, fmt.Errorf("extract protected header: %w", err)
+	}
+
+	iv, ct, tag, err := extractEncryptedParts(rawInput)
+	if err != nil {
+		return nil, fmt.Errorf("extract encrypted parts: %w", err)
+	}
+
+	switch enc {
+	case "A256GCM":
+		return decryptA256GCM(cek, iv, ct, tag, aad)
+	default:
+		return nil, fmt.Errorf("unsupported JWE enc algorithm: %q", enc)
+	}
+}
+
+func decryptA256GCM(cek, iv, ct, tag, aad []byte) ([]byte, error) {
+	if len(cek) != 32 {
+		return nil, fmt.Errorf("A256GCM requires 32-byte CEK, got %d", len(cek))
+	}
+	if len(iv) != 12 {
+		return nil, fmt.Errorf("A256GCM requires 12-byte IV, got %d", len(iv))
+	}
+	block, err := aes.NewCipher(cek)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(tag) != aead.Overhead() {
+		return nil, fmt.Errorf("A256GCM requires %d-byte tag, got %d", aead.Overhead(), len(tag))
+	}
+	combined := make([]byte, 0, len(ct)+len(tag))
+	combined = append(combined, ct...)
+	combined = append(combined, tag...)
+	return aead.Open(nil, iv, combined, aad)
+}
+
+// extractEncryptedParts returns base64url-decoded iv, ciphertext, tag
+// from a JWE in compact or JSON form.
+func extractEncryptedParts(rawInput []byte) (iv, ct, tag []byte, err error) {
+	trimmed := bytes.TrimSpace(rawInput)
+	if len(trimmed) == 0 {
+		return nil, nil, nil, fmt.Errorf("empty input")
+	}
+	var ivB64, ctB64, tagB64 string
+	if trimmed[0] == '{' {
+		var obj struct {
+			IV         string `json:"iv"`
+			Ciphertext string `json:"ciphertext"`
+			Tag        string `json:"tag"`
+		}
+		if err := json.Unmarshal(trimmed, &obj); err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid JWE JSON: %w", err)
+		}
+		ivB64, ctB64, tagB64 = obj.IV, obj.Ciphertext, obj.Tag
+	} else {
+		segs := bytes.Split(trimmed, []byte("."))
+		if len(segs) != 5 {
+			return nil, nil, nil, fmt.Errorf("invalid JWE compact form")
+		}
+		ivB64 = string(segs[2])
+		ctB64 = string(segs[3])
+		tagB64 = string(segs[4])
+	}
+	if iv, err = base64.RawURLEncoding.DecodeString(ivB64); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode iv: %w", err)
+	}
+	if ct, err = base64.RawURLEncoding.DecodeString(ctB64); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode ciphertext: %w", err)
+	}
+	if tag, err = base64.RawURLEncoding.DecodeString(tagB64); err != nil {
+		return nil, nil, nil, fmt.Errorf("decode tag: %w", err)
+	}
+	return iv, ct, tag, nil
 }

--- a/aead_test.go
+++ b/aead_test.go
@@ -1,6 +1,11 @@
 package clevis
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -47,4 +52,78 @@ func TestExtractEncodedProtectedHeaderJSONMissing(t *testing.T) {
 	input := []byte(`{"iv":"AAAA","ciphertext":"BBBB","tag":"CCCC"}`)
 	_, err := extractEncodedProtectedHeader(input)
 	require.Error(t, err)
+}
+
+// TestDecryptAEADWithCEK_A256GCM round-trips a known AES-256-GCM payload
+// using the exact same AAD-as-protected-header layout we'll use in
+// production.
+func TestDecryptAEADWithCEK_A256GCM(t *testing.T) {
+	cek := make([]byte, 32)
+	_, _ = rand.Read(cek)
+
+	iv := make([]byte, 12)
+	_, _ = rand.Read(iv)
+
+	plaintext := []byte("hello, clevis!")
+	aad := []byte("eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSJ9")
+
+	block, err := aes.NewCipher(cek)
+	require.NoError(t, err)
+	aead, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+	ctAndTag := aead.Seal(nil, iv, plaintext, aad)
+	ct := ctAndTag[:len(ctAndTag)-aead.Overhead()]
+	tag := ctAndTag[len(ctAndTag)-aead.Overhead():]
+
+	jwe := mustJSON(map[string]string{
+		"protected":  string(aad),
+		"iv":         base64.RawURLEncoding.EncodeToString(iv),
+		"ciphertext": base64.RawURLEncoding.EncodeToString(ct),
+		"tag":        base64.RawURLEncoding.EncodeToString(tag),
+	})
+
+	got, err := decryptAEADWithCEK(jwe, "A256GCM", cek)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, got)
+}
+
+// TestDecryptAEADWithCEK_TamperedAAD rejects when AAD doesn't match.
+func TestDecryptAEADWithCEK_TamperedAAD(t *testing.T) {
+	cek := make([]byte, 32)
+	_, _ = rand.Read(cek)
+	iv := make([]byte, 12)
+	_, _ = rand.Read(iv)
+	plaintext := []byte("payload")
+	originalAAD := []byte("eyJhbGciOiJFQ0RILUVTIn0")
+
+	block, _ := aes.NewCipher(cek)
+	aead, _ := cipher.NewGCM(block)
+	ctAndTag := aead.Seal(nil, iv, plaintext, originalAAD)
+	ct := ctAndTag[:len(ctAndTag)-aead.Overhead()]
+	tag := ctAndTag[len(ctAndTag)-aead.Overhead():]
+
+	jwe := mustJSON(map[string]string{
+		"protected":  "eyJhbGciOiJkaXIifQ", // tampered
+		"iv":         base64.RawURLEncoding.EncodeToString(iv),
+		"ciphertext": base64.RawURLEncoding.EncodeToString(ct),
+		"tag":        base64.RawURLEncoding.EncodeToString(tag),
+	})
+
+	_, err := decryptAEADWithCEK(jwe, "A256GCM", cek)
+	require.Error(t, err)
+}
+
+// TestDecryptAEADWithCEK_UnsupportedEnc returns a clear error.
+func TestDecryptAEADWithCEK_UnsupportedEnc(t *testing.T) {
+	_, err := decryptAEADWithCEK([]byte(`{"protected":"x","iv":"AAAA","ciphertext":"BBBB","tag":"CCCC"}`), "ChaCha20", []byte("k"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported")
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/aead_test.go
+++ b/aead_test.go
@@ -1,0 +1,50 @@
+package clevis
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractEncodedProtectedHeaderCompact verifies extraction from a 5-segment
+// compact JWE.
+func TestExtractEncodedProtectedHeaderCompact(t *testing.T) {
+	// header.encryptedKey.iv.ciphertext.tag, with arbitrary base64url content.
+	input := []byte("eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSJ9.ek.iv.ct.tag")
+	got, err := extractEncodedProtectedHeader(input)
+	require.NoError(t, err)
+	require.Equal(t, []byte("eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSJ9"), got)
+}
+
+// TestExtractEncodedProtectedHeaderJSON verifies extraction from the JWE
+// JSON serialization (multi-recipient form).
+func TestExtractEncodedProtectedHeaderJSON(t *testing.T) {
+	input := []byte(`{"protected":"eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSJ9","recipients":[{"header":{"alg":"dir"}}],"iv":"AAAA","ciphertext":"BBBB","tag":"CCCC"}`)
+	got, err := extractEncodedProtectedHeader(input)
+	require.NoError(t, err)
+	require.Equal(t, []byte("eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSJ9"), got)
+}
+
+// TestExtractEncodedProtectedHeaderInvalidCompact rejects malformed compact form.
+func TestExtractEncodedProtectedHeaderInvalidCompact(t *testing.T) {
+	cases := []string{
+		"only.three.segments", // not 5 segments, not JSON
+		"",                    // empty
+		"....",                // 5 segments but all empty — header empty is invalid
+	}
+	for _, c := range cases {
+		_, err := extractEncodedProtectedHeader([]byte(c))
+		require.Error(t, err, "input=%q should fail", c)
+		require.True(t, strings.Contains(err.Error(), "invalid") ||
+			strings.Contains(err.Error(), "empty"),
+			"input=%q err=%v", c, err)
+	}
+}
+
+// TestExtractEncodedProtectedHeaderJSONMissing rejects JSON missing "protected".
+func TestExtractEncodedProtectedHeaderJSONMissing(t *testing.T) {
+	input := []byte(`{"iv":"AAAA","ciphertext":"BBBB","tag":"CCCC"}`)
+	_, err := extractEncodedProtectedHeader(input)
+	require.Error(t, err)
+}

--- a/clevis.go
+++ b/clevis.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwe"
 )
 
@@ -89,29 +88,22 @@ func Decrypt(input []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	key, err := d.recoverKey(msg)
+	cek, err := d.recoverKey(msg)
 	if err != nil {
 		return nil, err
 	}
 
-	// The recovered key is already derived, so we use it as a _direct_ key
-	//
-	// However, the original message may have been encrypted with a different
-	// algorithm (e.g ECDH-ES). Since jwx complains if you try to decrypt
-	// a message with a direct key that was encrypted with ECDH-ES, we
-	// need to modify the message to use the direct key algorithm.
-	if err := msg.Recipients()[0].Headers().Set(jwe.AlgorithmKey, jwa.DIRECT()); err != nil {
-		return nil, err
+	// Extract the content-encryption algorithm from the protected header.
+	encAlg, ok := msg.ProtectedHeaders().ContentEncryption()
+	if !ok {
+		return nil, fmt.Errorf(`JWE protected header missing "enc" field`)
 	}
 
-	// Serialize the modified message and re-parse it
-	modifiedInput, err := json.Marshal(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Now try decryption using the direct key on the modified input
-	return jwe.Decrypt(modifiedInput, jwe.WithKey(jwa.DIRECT(), key))
+	// Bypass jwx's alg-matching pass: clevis JWEs intentionally carry
+	// alg=ECDH-ES (protected) and alg=dir (per-recipient), which jwx v3.1+
+	// hard-rejects as an RFC 7516 §7.2.1 disjoint-headers violation. We
+	// have the CEK; do the AEAD decrypt directly.
+	return decryptAEADWithCEK(input, encAlg.String(), cek)
 }
 
 func parseDecrypterConfig(pin string, config []byte) (decrypter, error) {


### PR DESCRIPTION
## Summary

Restores `Decrypt()` for consumers building against `lestrrat-go/jwx/v3 >= v3.1.0`. Without this fix, every clevis-encrypted LUKS volume becomes undecryptable through this library once the consumer's module graph resolves jwx to v3.1.x — the JWE is rejected at parse-time with `malformed JWE — "alg" header value differs between protected (...) and per-recipient (...) headers (RFC 7516 §7.2.1)`.

## Why this broke

Clevis JWEs intentionally carry two `alg` values:
- protected header: the wrap algorithm (e.g. `ECDH-ES`, `RSA-OAEP`)
- per-recipient header: `dir`, signalling the wrap-derived key is the CEK and no further unwrap step is needed

This dual encoding is what `clevis` (the C tool) has always emitted.

jwx ≤ v3.0.x tolerated it: the alg-matching loop iterated `[recipient, protected]` and used whichever it saw first. The existing workaround in `Decrypt()` exploited this by mutating the per-recipient `alg` to `dir` before re-marshaling and calling `jwe.Decrypt(..., WithKey(DIRECT, cek))`.

jwx v3.1.0 added a strict disjoint-headers check (`jwe/jwe.go:701-707` in v3.1.1) that fires **before** the alg loop. Conflicting `alg` values in the two locations now hard-reject the JWE.

There is no header-mutation strategy that satisfies both AEAD integrity (which signs the encoded protected-header bytes per RFC 7516 §5.1 step 14) and the new strict check.

## Fix

After the pin-specific `recoverKey` derives the CEK, perform the JWE AEAD-decrypt step locally with `crypto/cipher` rather than mutating the parsed message and re-calling `jwe.Decrypt`. This bypasses jwx's alg-matching entirely while preserving the AAD-as-encoded-protected-header contract.

- `aead.go` (new): `decryptAEADWithCEK`, `decryptA256GCM`, plus parsers for the encoded protected header, IV, ciphertext, and tag from compact and JSON serialization forms. Pure stdlib (`crypto/aes`, `crypto/cipher`, `encoding/base64`, `encoding/json`).
- `clevis.go`: `Decrypt()` swaps the final block (mutate header + marshal + `jwe.Decrypt`) for a single call to `decryptAEADWithCEK(input, encAlg.String(), cek)`. The `jwa` import is dropped (no longer referenced).

## Backward compatibility

No `go.mod` change. The fix code uses only public jwx APIs that exist in both v3.0.x and v3.1.x. Verified:

- Against `jwx v3.0.13`: builds clean, all tests pass (consumers on v3.0.x — who don't have the bug — see no behavior change).
- Against `jwx v3.1.1`: builds clean, all tests pass — including the ones that fail without this PR.

## Verification

- Existing decrypt suite: `TestDecryptTangSHA1/256`, `TestDecryptTangNoThumbprint`, `TestDecryptURLWithoutScheme`, `TestDecryptIP`, `TestDecryptSss`, `TestDecryptTpm2Emulator`, plus their Encrypt round-trip siblings — PASS against both v3.0.13 and v3.1.1.
- New unit tests in `aead_test.go`: A256GCM happy path, tampered-AAD rejection (GCM tag mismatch), unsupported-enc rejection, compact-form extraction, JSON-form extraction, malformed-input rejection — PASS.
- End-to-end against the downstream booster initramfs project (QEMU vmtest with real LUKS images): `TestLUKS1ClevisTang`, `TestLUKS2ClevisTang`, `TestLUKS2ClevisTangDHCP`, `TestLUKS1ClevisTpm2`, `TestLUKS2ClevisTpm2` — PASS via local `replace` directive.

## Out of scope

- The clevis C tool's JWE format is unchanged. This PR only changes how the Go library decrypts that format.
- Only `A256GCM` is implemented in the manual AEAD path (covers all observed clevis emissions and the entire test suite). Other `enc` algorithms (`A128CBC-HS256`, etc.) can be added trivially behind the existing `switch enc` if a real fixture surfaces them.